### PR TITLE
update to quick_xml 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "LGPL-3.0"
 chrono = "0.2"
 curl = "0.2"
 log = "0.3"
-quick-xml = "0.1"
+quick-xml = "0.2"
 url = "0.5"
 
 [features]

--- a/src/feedio/feed_reader.rs
+++ b/src/feedio/feed_reader.rs
@@ -38,7 +38,7 @@ impl FeedReader {
         let mut element = "channel";
         let mut name = "";
 
-        let reader = XmlReader::from_str(&feed_string).trim_text(true);
+        let reader = XmlReader::from(&*feed_string).trim_text(true);
         for r in reader {
             match r {
                 Ok(Event::Start(ref e)) => {


### PR DESCRIPTION
I've updated quick_xml to 0.2.0 and there is a breaking change (following clippy advice, `from_str` as been replaced with `From<&str>`)
